### PR TITLE
#43: вынес dev-депсы отдельно

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,17 @@
   "private": true,
   "homepage": "https://avdotion.github.io/clue",
   "dependencies": {
+    "clipboard-polyfill": "^2.8.6",
+    "crypto-es": "^1.2.2",
+    "immer": "^5.3.6",
+    "normalize.css": "^8.0.1",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-redux": "^7.2.0",
+    "redux": "^4.0.5",
+    "reshadow": "0.0.1-alpha.74"
+  },
+  "devDependencies": {
     "@babel/core": "7.8.4",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "^4.2.4",
@@ -23,8 +34,6 @@
     "babel-preset-react-app": "^9.1.1",
     "camelcase": "^5.3.1",
     "case-sensitive-paths-webpack-plugin": "2.3.0",
-    "clipboard-polyfill": "^2.8.6",
-    "crypto-es": "^1.2.2",
     "css-loader": "3.4.2",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0",
@@ -41,7 +50,6 @@
     "html-webpack-plugin": "4.0.0-beta.11",
     "husky": "^4.2.3",
     "identity-obj-proxy": "3.0.0",
-    "immer": "^5.3.6",
     "jest": "24.9.0",
     "jest-environment-jsdom-fourteen": "1.0.1",
     "jest-resolve": "24.9.0",
@@ -49,7 +57,6 @@
     "lint-staged": "^10.0.7",
     "mini-css-extract-plugin": "0.9.0",
     "minimist": "^1.2.0",
-    "normalize.css": "^8.0.1",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pnp-webpack-plugin": "1.6.0",
     "postcss-flexbugs-fixes": "4.1.0",
@@ -57,13 +64,8 @@
     "postcss-normalize": "8.0.1",
     "postcss-preset-env": "6.7.0",
     "postcss-safe-parser": "4.0.1",
-    "react": "^16.12.0",
     "react-app-polyfill": "^1.0.6",
     "react-dev-utils": "^10.2.0",
-    "react-dom": "^16.12.0",
-    "react-redux": "^7.2.0",
-    "redux": "^4.0.5",
-    "reshadow": "0.0.1-alpha.74",
     "resolve": "1.15.0",
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",
@@ -82,10 +84,10 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test:eslint": "eslint --ext .jsx,.js,.ts,.tsx src/ --color --cache",
+    "test:eslint": "./node_modules/.bin/eslint --ext .jsx,.js,.ts,.tsx src/ --color --cache",
     "test:typescript": "./node_modules/.bin/tsc -p .",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "./node_modules/.bin/gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Бонус: скрипты теперь зависят от локальных пакетов, а не глобальных. Для того, чтобы разобраться с тем, что надо, а что нет, использовал [source-map-explorer](https://create-react-app.dev/docs/analyzing-the-bundle-size/).